### PR TITLE
#29168 - make group handlers not mandatory

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -395,6 +395,8 @@ export default class Timeline extends React.Component {
     onRowClick() {},
     onRowContext() {},
     onRowDoubleClick() {},
+    onGroupRowClick() {},
+    onGroupRowDoubleClick() {},
     onInteraction() {},
     itemRendererDefaultProps: {},
     backgroundLayer: null


### PR DESCRIPTION
Issues fixed:
 * group handlers was considered mandatory in Timeline